### PR TITLE
Fix bullet puffs in freeaim_direct mode.

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1636,7 +1636,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
 	  // fix bullet-eaters -- killough:
 	  if  (li->backsector && li->backsector->ceilingpic == skyflatnum)
     {
-      if(!mouselook && freeaim != freeaim_direct && !casual_play)
+      if(!casual_play)
       {
 	      if (demo_compatibility || li->backsector->ceilingheight < z)
 	        return false;
@@ -1649,7 +1649,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
       // [nugget] Taken from Crispy Doom - check if the bullet puff's z-coordinate is below of above
       // its spawning sector's floor or ceiling, respectively, and move its
       // coordinates to the point where the trajectory hits the plane
-      if (mouselook && freeaim == freeaim_direct && casual_play)
+      if (casual_play)
       {
           const int lineside = P_PointOnLineSide(x, y, li);
           int side;

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1635,9 +1635,38 @@ static boolean PTR_ShootTraverse(intercept_t *in)
 	  // it's a sky hack wall
 	  // fix bullet-eaters -- killough:
 	  if  (li->backsector && li->backsector->ceilingpic == skyflatnum)
-	    if (demo_compatibility || li->backsector->ceilingheight < z)
-	      return false;
+    {
+      if(!mouselook && freeaim != freeaim_direct && !casual_play)
+      {
+	      if (demo_compatibility || li->backsector->ceilingheight < z)
+	        return false;
+      }
+      else
+        if (li->backsector->ceilingheight < z) // [nugget] freeaim - fix disappearing bullet puffs when outside
+          return false;
+    }
 	}
+      // [nugget] Taken from Crispy Doom - check if the bullet puff's z-coordinate is below of above
+      // its spawning sector's floor or ceiling, respectively, and move its
+      // coordinates to the point where the trajectory hits the plane
+      if (mouselook && freeaim == freeaim_direct && casual_play)
+      {
+          const int lineside = P_PointOnLineSide(x, y, li);
+          int side;
+
+          if ((side = li->sidenum[lineside]) != NO_INDEX)
+          {
+              const sector_t* const sector = sides[side].sector;
+
+              if (z < sector->floorheight || (z > sector->ceilingheight && sector->ceilingpic != skyflatnum))
+              {
+                  z = BETWEEN(sector->floorheight, sector->ceilingheight, z);
+                  frac = FixedDiv(z - shootz, FixedMul(aimslope, attackrange));
+                  x = trace.x + FixedMul(trace.dx, frac);
+                  y = trace.y + FixedMul(trace.dy, frac);
+              }
+          }
+      }
 
       // Spawn bullet puffs.
 

--- a/src/p_map.h
+++ b/src/p_map.h
@@ -91,6 +91,7 @@ extern mobj_t *linetarget;     // who got hit (or NULL)
 extern msecnode_t *sector_list;                             // phares 3/16/98
 extern fixed_t tmbbox[4];         // phares 3/20/98
 extern line_t *blockline;   // killough 8/11/98
+extern boolean mouselook;   // [nugget] freeaim - fix bullet puffs
 
 #endif // __P_MAP__
 


### PR DESCRIPTION
Spawn bullet puffs at bullet impact coordinates when in freeaim_direct mode.