### PR TITLE
Fix caching of certain NUGHUD patches

### DIFF
--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -844,7 +844,7 @@ void ST_drawWidgets(void)
 
         if (lump[i] >= 0)
         { V_DrawPatch(nughud.patches[i].x + DELTA(nughud.patches[i].wide),
-                      nughud.patches[i].y, FG, W_CacheLumpNum(lump[i], PU_CACHE)); }
+                      nughud.patches[i].y, FG, W_CacheLumpNum(lump[i], PU_STATIC)); }
       }
 
   // used by w_arms[] widgets
@@ -895,7 +895,7 @@ void ST_drawWidgets(void)
       }
       
       if (lump >= 0) {
-        patch = W_CacheLumpNum(lump, PU_CACHE);
+        patch = W_CacheLumpNum(lump, PU_STATIC);
         
         // [crispy] (23,179) is the center of the Ammo widget
         // [Nugget] Nugget HUD


### PR DESCRIPTION
NUGHUD allows to draw any (?) patch available in the loaded WADs.

Some of these patches are, of course, graphics used by other parts of the game, and some of them are given the `PU_STATIC` tag when cached, and the code doesn't expect them to be purged upon e.g. ending a level. However, up until now, all patches cached by NUGHUD were given the `PU_CACHE` tag, so they _were_ purged rather often (including exiting of a level).

This can be problem, for example, with the Status Bar graphics; these are normally cached only upon initializing the Status Bar, which only happens when (re)starting the screen. If NUGHUD were to use any of those graphics, though, it'd attempt to cache them again, giving them the `PU_CACHE` tag and therefore purging them upon exiting a level. NUGHUD may then cache those graphics again, but the Status Bar code won't, and the pointers it uses aren't updated, so a crash occurs.

This potential fix addresses that by making the NUGHUD code cache patches with the `PU_STATIC` tag. They might be cached by other code later and given the `PU_CACHE` tag, but NUGHUD _can_ seemingly handle that.