### PR TITLE
Rewind tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Changes
 
+- **Rewind improvements:**
+  - Only delete key frames when rewinding within less than 0.6 seconds since the last rewind
+  - "Aligned" key-framing time
 - **Support for _Milestone Completion Announcements_ in multiplayer**
 
 ## Bug Fixes

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -3107,10 +3107,8 @@ void G_Ticker(void)
       && gamestate == GS_LEVEL && oldleveltime < leveltime
       && players[consoleplayer].playerstate != PST_DEAD)
   {
-    if (!rewind_countdown)
+    if (--rewind_countdown <= 0)
     { G_SaveKeyFrame(); }
-    else
-    { rewind_countdown--; }
   }
   else if (!CASUALPLAY(rewind_depth) || gamestate != GS_LEVEL)
   {

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2822,6 +2822,24 @@ static void G_SaveKeyFrame(void)
 
 static void G_DoRewind(void)
 {
+  static int last_rewind_time = 0;
+
+  if ((0 <= keyframe_index - 1)
+      && (gametic - last_rewind_time <= 21)) // 0.6 seconds
+  {
+    keyframe_index--;
+
+    Z_Free(keyframe_list_tail->frame);
+
+    keyframe_list_tail = keyframe_list_tail->prev;
+    Z_Free(keyframe_list_tail->next);
+    keyframe_list_tail->next = NULL;
+  }
+
+  last_rewind_time = gametic;
+
+  G_ResetRewindCountdown();
+
   int length, i;
 
   I_SetFastdemoTimer(false);
@@ -2943,19 +2961,6 @@ static void G_DoRewind(void)
   R_FillBackScreen(); // draw the pattern into the back screen
 
   displaymsg("Restored key frame %i", keyframe_index);
-
-  if (0 <= keyframe_index - 1)
-  {
-    keyframe_index--;
-
-    Z_Free(savebuffer);
-
-    keyframe_list_tail = keyframe_list_tail->prev;
-    Z_Free(keyframe_list_tail->next);
-    keyframe_list_tail->next = NULL;
-  }
-
-  G_ResetRewindCountdown();
 }
 
 void G_EnableRewind(void)

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -114,7 +114,7 @@ extern int cpars[];     // hardcoded array size
 
 // [Nugget] Rewind -----------------------------------------------------------
 
-extern void G_ResetRewindCountdown(void);
+extern void G_SetRewindCountdown(int value);
 extern void G_EnableRewind(void);
 extern void G_Rewind(void);
 extern void G_ClearExcessKeyFrames(void);

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2733,7 +2733,7 @@ setup_menu_t gen_settings8[] = {
 static void UpdateRewindInterval(void)
 {
   G_EnableRewind();
-  G_ResetRewindCountdown();
+  G_SetRewindCountdown((rewind_interval * TICRATE) - ((leveltime - 1) % (rewind_interval * TICRATE)));
 }
 
 static void UpdateRewindDepth(void)


### PR DESCRIPTION
Now, key frames will only be deleted if the user rewinds within less than 0.6 seconds (21 tics, give or take one tic) since the last rewind.

To do: always store a key frame upon loading levels.